### PR TITLE
Don't open_locale classical

### DIFF
--- a/src/archive.lean
+++ b/src/archive.lean
@@ -11,7 +11,7 @@ import general
 noncomputable theory
 -- open_locale classical
 open nat finset list finsupp set function filter measure_theory
-open_locale classical topological_space interval big_operators filter ennreal asymptotics
+open_locale topological_space interval big_operators filter ennreal asymptotics
 
 namespace squarefree_sums
 

--- a/src/defs.lean
+++ b/src/defs.lean
@@ -7,11 +7,14 @@ import measure_theory.integral.interval_integral
 
 noncomputable theory
 open nat finset function filter
-open_locale classical topological_space interval big_operators filter asymptotics arithmetic_function
+open_locale topological_space interval big_operators filter asymptotics arithmetic_function
 
 namespace squarefree_sums
 
 def is_square (n : ℕ) : Prop := ∃ s, s * s = n
+
+instance : decidable_pred (is_square : ℕ → Prop)
+| n := decidable_of_iff' _ (nat.exists_mul_self n)
 
 def ssqrt (n : ℕ) := ite (is_square n) (sqrt n) 0
 
@@ -38,9 +41,6 @@ def squarefree_nat : arithmetic_function ℤ :=
     simp [this],
   }),
 ⟩
-
-instance : decidable_pred (is_square : ℕ → Prop)
-| n := decidable_of_iff' _ (nat.exists_mul_self n)
 
 def is_Ot {α : Type*} (f : α → ℝ) (g : α → ℝ) (h : α → ℝ) (l : filter α) : Prop :=
 ∃ c : ℝ, asymptotics.is_O_with c (f - g) h l

--- a/src/lemmas_on_asymptotics.lean
+++ b/src/lemmas_on_asymptotics.lean
@@ -2,7 +2,7 @@ import defs
 
 noncomputable theory
 open nat finset function filter asymptotics
-open_locale classical topological_space interval big_operators filter asymptotics arithmetic_function
+open_locale topological_space interval big_operators filter asymptotics arithmetic_function
 
 -- h and h' are errors
 variables {α : Type*} {f : α → ℝ} {g : α → ℝ} {h : α → ℝ} {h' : α → ℝ} {k : α → ℝ} {l : filter α}

--- a/src/lemmas_on_defs.lean
+++ b/src/lemmas_on_defs.lean
@@ -9,7 +9,7 @@ import defs
 
 noncomputable theory
 open nat finset function filter
-open_locale classical topological_space interval big_operators filter asymptotics arithmetic_function
+open_locale topological_space interval big_operators filter asymptotics arithmetic_function
 
 namespace squarefree_sums
 
@@ -146,8 +146,11 @@ lemma ssqrt_eq {n : ℕ} : ssqrt (n * n) = n :=
 begin
   unfold ssqrt,
   rw sqrt_eq,
-  unfold is_square,
-  simp,
+  have : is_square (n * n), {
+    unfold is_square,
+    use n,
+  },
+  simp [this],
 end
 
 lemma squarefree_eq_μ_μ : squarefree_nat = arithmetic_function.pmul μ μ :=

--- a/src/lemmas_on_tendsto.lean
+++ b/src/lemmas_on_tendsto.lean
@@ -11,7 +11,7 @@ import summability
 noncomputable theory
 -- open_locale classical
 open nat finset list finsupp set function filter measure_theory
-open_locale classical topological_space interval big_operators filter ennreal asymptotics
+open_locale topological_space interval big_operators filter ennreal asymptotics
 
 variables {α : Type*} [preorder α]
 

--- a/src/moebius_notes.lean
+++ b/src/moebius_notes.lean
@@ -14,7 +14,7 @@ import integral_facts
 
 noncomputable theory
 open nat finset function filter
-open_locale classical topological_space interval big_operators filter asymptotics arithmetic_function
+open_locale topological_space interval big_operators filter asymptotics arithmetic_function
 
 namespace squarefree_sums
 

--- a/src/multiplicativity.lean
+++ b/src/multiplicativity.lean
@@ -10,7 +10,7 @@ import lemmas_on_defs
 
 noncomputable theory
 open nat finset function filter
-open_locale classical topological_space interval big_operators filter asymptotics arithmetic_function
+open_locale topological_space interval big_operators filter asymptotics arithmetic_function
 
 namespace squarefree_sums
 -- Multiplicativity

--- a/src/squarefree_rw.lean
+++ b/src/squarefree_rw.lean
@@ -11,7 +11,7 @@ import multiplicativity
 
 noncomputable theory
 open nat finset function filter
-open_locale classical topological_space interval big_operators filter asymptotics arithmetic_function
+open_locale topological_space interval big_operators filter asymptotics arithmetic_function
 
 namespace squarefree_sums
 

--- a/src/summability.lean
+++ b/src/summability.lean
@@ -13,7 +13,7 @@ import general
 
 noncomputable theory
 open nat finset function filter
-open_locale classical topological_space interval big_operators filter asymptotics arithmetic_function
+open_locale topological_space interval big_operators filter asymptotics arithmetic_function
 
 namespace squarefree_sums
 


### PR DESCRIPTION
It's not actually necessary if you deal with the decidability issues correctly inside of `ssqrt`. Removed on Kevin Buzzard's recommendation